### PR TITLE
allow unsetting the logger

### DIFF
--- a/Psr/Log/LoggerAwareInterface.php
+++ b/Psr/Log/LoggerAwareInterface.php
@@ -10,8 +10,8 @@ interface LoggerAwareInterface
     /**
      * Sets a logger instance on the object
      *
-     * @param LoggerInterface $logger
+     * @param LoggerInterface|null $logger
      * @return null
      */
-    public function setLogger(LoggerInterface $logger);
+    public function setLogger(LoggerInterface $logger = null);
 }

--- a/Psr/Log/LoggerAwareTrait.php
+++ b/Psr/Log/LoggerAwareTrait.php
@@ -7,7 +7,9 @@ namespace Psr\Log;
  */
 trait LoggerAwareTrait
 {
-    /** @var LoggerInterface */
+    /**
+     * @var LoggerInterface|null
+     */
     protected $logger;
 
     /**
@@ -15,7 +17,7 @@ trait LoggerAwareTrait
      * 
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
As the created object is not forced to have a logger in the first place,
it should be valid to use the mutator to unset the logger again.