### PR TITLE
CallbackLogger to create easy ad hoc logger instances.

### DIFF
--- a/Psr/Log/CallbackLogger.php
+++ b/Psr/Log/CallbackLogger.php
@@ -11,6 +11,9 @@ class CallbackLogger extends AbstractLogger
 
     public function __construct($callback)
     {
+        if (!is_callable($callback)) {
+            throw new InvalidArgumentException('Callback function not callable');
+        }
         $this->callback = $callback;
     }
 


### PR DESCRIPTION
A logger basically only consists of a single function to log. This class makes it easy to create a ad hoc logger.

If one wants to output all log messages to the stdout in a cli script one can now just do

``` php
$loggerAware->setLogger(new CallbackLogger(function($level, $message, array $context) {
    echo $level . ': ' . $message . "\n";
});
```

I can imagine this also being a great addition to create a MockLogger in unit tests. Altough you're probably better off with a shared MockLogger class there anyway.
