### PR TITLE
Added LoggerInterface::exception() interface method

### DIFF
--- a/Psr/Log/AbstractLogger.php
+++ b/Psr/Log/AbstractLogger.php
@@ -117,4 +117,18 @@ abstract class AbstractLogger implements LoggerInterface
     {
         $this->log(LogLevel::DEBUG, $message, $context);
     }
+
+    /**
+     * Exception information.
+     *
+     * @param \Exception $exception
+     * @param mixed $level
+     * @param array $context
+     * @return null
+     */
+    public function exception(\Exception $exception, $level = LogLevel::ERROR, array $context = array())
+    {
+        $context["exception"] = $exception;
+        $this->log($level, $exception->getMessage(), $context);
+    }
 }

--- a/Psr/Log/LoggerInterface.php
+++ b/Psr/Log/LoggerInterface.php
@@ -111,4 +111,14 @@ interface LoggerInterface
      * @return null
      */
     public function log($level, $message, array $context = array());
+
+    /**
+     * Logs information about an exception.
+     *
+     * @param \Exception $exception
+     * @param mixed $level
+     * @param array $context
+     * @return null
+     */
+    public function exception(\Exception $exception, $level = LogLevel::ERROR, array $context = array());
 }

--- a/Psr/Log/LoggerTrait.php
+++ b/Psr/Log/LoggerTrait.php
@@ -120,6 +120,20 @@ trait LoggerTrait
     }
 
     /**
+     * Exception information.
+     *
+     * @param \Exception $exception
+     * @param mixed $level
+     * @param array $context
+     * @return null
+     */
+    public function exception(\Exception $exception, $level = LogLevel::ERROR, array $context = array())
+    {
+        $context["exception"] = $exception;
+        $this->log($level, $exception->getMessage(), $context);
+    }
+
+    /**
      * Logs with an arbitrary level.
      *
      * @param mixed $level

--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -123,6 +123,21 @@ abstract class LoggerInterfaceTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals($expected, $this->getLogs());
     }
+
+    /**
+     * @dataProvider provideLevelsAndMessages
+     */
+    public function testLogsExceptionAtAllLevels($level, $message)
+    {
+        $logger = $this->getLogger();
+        $exception = new \Exception($message);
+        $logger->exception($exception, $level, array('user' => 'Bob'));
+
+        $expected = array(
+            $level.' message of level '.$level.' with context: Bob',
+        );
+        $this->assertEquals($expected, $this->getLogs());
+    }
 }
 
 class DummyTest


### PR DESCRIPTION
For increased simplicity for logging exceptions, this patch adds an `exception()` method to the `LoggerInterface`.

This makes it much easier to log exceptions in a consistent way without loss of any existing functionality.

Currently, exceptions must be logged using verbose code:
```php
$logger->error($e->getMessage(), array("exception" => $e));
```
This is simplified to:

```php
$logger->exception($e);
    
// Optionally, the severity level can be overridden and context params can be set:
$logger->exception($e, LogLevel::INFO, array("foo" => "bar"));
```