### PR TITLE
Fixes #8: PSR-3 claims to follow RFC 5424 but LogLevel constants do not.

### DIFF
--- a/Psr/Log/LogLevel.php
+++ b/Psr/Log/LogLevel.php
@@ -3,16 +3,49 @@
 namespace Psr\Log;
 
 /**
- * Describes log levels
+ * Defines RFC 5424 log levels.
+ *
+ * @see http://tools.ietf.org/html/rfc5424#section-6.2.1
  */
 class LogLevel
 {
-    const EMERGENCY = 'emergency';
-    const ALERT = 'alert';
-    const CRITICAL = 'critical';
-    const ERROR = 'error';
-    const WARNING = 'warning';
-    const NOTICE = 'notice';
-    const INFO = 'info';
-    const DEBUG = 'debug';
+    /**
+     * Emergency: system is unusable.
+     */
+    const EMERGENCY = 0;
+
+    /**
+     * Alert: action must be taken immediately.
+     */
+    const ALERT = 1;
+
+    /**
+     * Critical: critical conditions.
+     */
+    const CRITICAL = 2;
+
+    /**
+     * Error: error conditions.
+     */
+    const ERROR = 3;
+
+    /**
+     * Warning: warning conditions.
+     */
+    const WARNING = 4;
+
+    /**
+     * Notice: normal but significant condition.
+     */
+    const NOTICE = 5;
+
+    /**
+     * Informational: informational messages.
+     */
+    const INFO = 6;
+
+    /**
+     * Debug: debug-level messages.
+     */
+    const DEBUG = 7;
 }

--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -34,11 +34,11 @@ abstract class LoggerInterfaceTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideLevelsAndMessages
      */
-    public function testLogsAtAllLevels($level, $message)
+    public function testLogsAtAllLevels($severity, $level, $message)
     {
         $logger = $this->getLogger();
         $logger->{$level}($message, array('user' => 'Bob'));
-        $logger->log($level, $message, array('user' => 'Bob'));
+        $logger->log($severity, $message, array('user' => 'Bob'));
 
         $expected = array(
             $level.' message of level '.$level.' with context: Bob',
@@ -50,14 +50,14 @@ abstract class LoggerInterfaceTest extends \PHPUnit_Framework_TestCase
     public function provideLevelsAndMessages()
     {
         return array(
-            LogLevel::EMERGENCY => array(LogLevel::EMERGENCY, 'message of level emergency with context: {user}'),
-            LogLevel::ALERT => array(LogLevel::ALERT, 'message of level alert with context: {user}'),
-            LogLevel::CRITICAL => array(LogLevel::CRITICAL, 'message of level critical with context: {user}'),
-            LogLevel::ERROR => array(LogLevel::ERROR, 'message of level error with context: {user}'),
-            LogLevel::WARNING => array(LogLevel::WARNING, 'message of level warning with context: {user}'),
-            LogLevel::NOTICE => array(LogLevel::NOTICE, 'message of level notice with context: {user}'),
-            LogLevel::INFO => array(LogLevel::INFO, 'message of level info with context: {user}'),
-            LogLevel::DEBUG => array(LogLevel::DEBUG, 'message of level debug with context: {user}'),
+            array(LogLevel::EMERGENCY, 'emergency', 'message of level emergency with context: {user}'),
+            array(LogLevel::ALERT, 'alert', 'message of level alert with context: {user}'),
+            array(LogLevel::CRITICAL, 'critical', 'message of level critical with context: {user}'),
+            array(LogLevel::ERROR, 'error', 'message of level error with context: {user}'),
+            array(LogLevel::WARNING, 'warning', 'message of level warning with context: {user}'),
+            array(LogLevel::NOTICE, 'notice', 'message of level notice with context: {user}'),
+            array(LogLevel::INFO, 'info', 'message of level info with context: {user}'),
+            array(LogLevel::DEBUG, 'debug', 'message of level debug with context: {user}'),
         );
     }
 


### PR DESCRIPTION
[PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md) claims to use RFC 5424 log levels:

> The `LoggerInterface` exposes eight methods to write logs to the eight [RFC 5424](http://tools.ietf.org/html/rfc5424) levels (debug, info, notice, warning, error, critical, alert, emergency).

Problem: The log message severity levels are defined as strings, which causes PSR-3 to violate RFC 5424.

http://tools.ietf.org/html/rfc5424#section-6.2.1 clearly defines:
> 
        Numerical         Severity
          Code
           0       Emergency: system is unusable
           1       Alert: action must be taken immediately
           2       Critical: critical conditions
           3       Error: error conditions
           4       Warning: warning conditions
           5       Notice: normal but significant condition
           6       Informational: informational messages
           7       Debug: debug-level messages
>
           Table 2. syslog Message Severities

RFC 5424 is the successor of [RFC 3164](http://tools.ietf.org/html/rfc3164#section-4.1.1).  The IETF standard for log message severities exists since 2001.

It's not clear why PSR-3 was entirely modeled after RFC 5424, and even includes literal copies of text fragments, but suddenly diverges from it in `LogLevel` constant values.

As [discussed here](https://github.com/php-fig/log/issues/8#issuecomment-42897728) this causes PSR-3 to **not** meet the goal of interoperability (it's primary objective).

I can see two options:

A. Change the constant values to adhere to RFC 5424. (code change)
B. Stop pretending that PSR-3 has anything to do with RFC 5424. (textual spec change)

---
(Incomplete) List of projects that are following the IETF standard:

* [Zend Framework 2](https://github.com/zendframework/zf2/blob/master/library/Zend/Log/Logger.php#L24)
* [Lithium](https://github.com/UnionOfRAD/lithium/blob/master/analysis/Logger.php#L73)
* [Phalcon](https://github.com/phalcon/cphalcon/blob/master/ext/logger.h#L25-L32)
* [CakePHP](https://github.com/cakephp/cakephp/blob/master/lib/Cake/Log/CakeLog.php#L91)
* [Drupal](https://github.com/drupal/drupal/blob/8.0-alpha11/core/includes/bootstrap.inc#L82-L120)
* [IDK Framework](https://github.com/peeter-tomberg/IDK-Framework/blob/master/AppConfig/Logger.php#L5-L16)
* [TYPO3 CMS](https://git.typo3.org/Packages/TYPO3.CMS.git/blob/HEAD:/typo3/sysext/core/Classes/Log/LogLevel.php#l31)
* [TYPO3 Flow](https://git.typo3.org/Packages/TYPO3.Flow.git/blob/HEAD:/Classes/TYPO3/Flow/Log/Logger.php#l86) *(implicitly by using PHP `LOG_` constants)*
* [php-logger-essentials](https://github.com/rkrx/php-logger-essentials) _…only exists to correct this problem._

Out of all other analyzed projects, most are using custom integers (e.g., [Monolog](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Logger.php#L29-L77), [Joomla](https://github.com/joomla-framework/log/blob/master/src/Log.php#L33-L95), Mediawiki).

Excluding the (1-2) projects that migrated to PSR-3 already, this research yielded only 1-2 projects using strings ([Yii Framework](https://github.com/yiisoft/yii/blob/master/framework/logging/CLogger.php#L35-L37) + another I forgot to record).
