### PR TITLE
Remove abstract member function "log" from trait "LoggerTrait".

### DIFF
--- a/Psr/Log/LoggerTrait.php
+++ b/Psr/Log/LoggerTrait.php
@@ -118,14 +118,4 @@ trait LoggerTrait
     {
         $this->log(LogLevel::DEBUG, $message, $context);
     }
-
-    /**
-     * Logs with an arbitrary level.
-     *
-     * @param mixed $level
-     * @param string $message
-     * @param array $context
-     * @return null
-     */
-    abstract public function log($level, $message, array $context = array());
 }


### PR DESCRIPTION
A class using `\Psr\Log\LoggerTrait` should always implement `\Psr\Log\LoggerInterface`. I can not not see a reason why the member function `log` is included in the trait `\Psr\Log\LoggerTrait`. The following should not be written and is forbidden (with or without this PR):

``` php
<?php
class NonVirtualLogger
{
    use \Psr\Log\LoggerTrait;
}
```

IMO the `log` member function should always implemented via the interface. Otherwise the user "disables" polymorphism. That means each concrete logger must implement `\Psr\Log\LoggerInterface` directly or indirectly (e.g. via `\Psr\Log\AbstractLogger`).

Example:

``` php
<?php
// Just a quick example to demonstrate the functionality. Do not use.

namespace FlorianWolters\Example;

require_once 'LogLevel.php';
require_once 'LoggerInterface.php';
require_once 'LoggerTrait.php';
require_once 'AbstractLogger.php';

// Example 1: Implement interface and use trait. Recommended for PHP >= 5.4.

class ConsoleLogger implements \Psr\Log\LoggerInterface
{
    use \Psr\Log\LoggerTrait;

    public function log($level, $message, array $context = array())
    {
        echo $level . ": " . $message . "\n";
    }
}

// Example 2: Use abstract base class. Required for PHP < 5.4.

class NullLogger extends \Psr\Log\AbstractLogger
{
    public function log($level, $message, array $context = array())
    {
        // noop
    }
}

$message = 'hello, world';
$loggers = array(new ConsoleLogger, new NullLogger);

foreach ($loggers as $logger)
{
    $logger->emergency($message);
    $logger->alert($message);
    $logger->critical($message);
    $logger->error($message);
    $logger->warning($message);
    $logger->info($message);
    $logger->notice($message);
    $logger->debug($message);
    $logger->log(\Psr\Log\LogLevel::DEBUG, $message);
}
```
