### PR TITLE
Use PSR-4 without moving any files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "Psr\\Log\\": ""
+        "psr-4": {
+            "Psr\\Log\\": "Psr/Log/"
         }
     },
     "extra": {


### PR DESCRIPTION
PSR-0 is deprecated, so shouldn't we use PSR-4 now? Note that to retain BC with people not using the composer provided autoloader, I have not moved any of the files.