### PR TITLE
Code alignment in LogLevel class

### DIFF
--- a/Psr/Log/LogLevel.php
+++ b/Psr/Log/LogLevel.php
@@ -8,11 +8,11 @@ namespace Psr\Log;
 class LogLevel
 {
     const EMERGENCY = 'emergency';
-    const ALERT = 'alert';
-    const CRITICAL = 'critical';
-    const ERROR = 'error';
-    const WARNING = 'warning';
-    const NOTICE = 'notice';
-    const INFO = 'info';
-    const DEBUG = 'debug';
+    const ALERT     = 'alert';
+    const CRITICAL  = 'critical';
+    const ERROR     = 'error';
+    const WARNING   = 'warning';
+    const NOTICE    = 'notice';
+    const INFO      = 'info';
+    const DEBUG     = 'debug';
 }


### PR DESCRIPTION
Aligned code to improve readability - this also now matches the PSR-3 document (which had lines aligned).

https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md