### PR TITLE
Make LoggerAwareTrait more helpful for integrating projects

### DIFF
--- a/Psr/Log/LoggerAwareInterface.php
+++ b/Psr/Log/LoggerAwareInterface.php
@@ -8,11 +8,18 @@ namespace Psr\Log;
 interface LoggerAwareInterface
 {
     /**
+     * Gets the logger.
+     * 
+     * @return LoggerInterface
+     */
+    public function getLogger();
+    
+    /**
      * Sets a logger instance on the object.
      *
      * @param LoggerInterface $logger
      *
-     * @return null
+     * @return static
      */
     public function setLogger(LoggerInterface $logger);
 }

--- a/Psr/Log/LoggerAwareTrait.php
+++ b/Psr/Log/LoggerAwareTrait.php
@@ -13,14 +13,30 @@ trait LoggerAwareTrait
      * @var LoggerInterface
      */
     protected $logger;
+    
+    /**
+     * Gets the logger.
+     * 
+     * @return LoggerInterface
+     */
+    public function getLogger()
+    {
+        if (!isset($this->logger)) {
+            $this->logger = new NullLogger();
+        }
+        return $this->logger;
+    }
 
     /**
      * Sets a logger.
      *
      * @param LoggerInterface $logger
+     * 
+     * @return static
      */
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+        return $this;
     }
 }


### PR DESCRIPTION
There are a couple of things that I have to do to *every* project I use with the psr logger aware interface and traits, and end up having to create duplicate code every time. It would be nice if we could improve the usefulness of the aware interface and trait.

* Add a getLogger() method that defaults to NullLogger().
* Return static from setLogger() to allow it to be chained.