### PR TITLE
Add homepage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "psr/log",
     "description": "Common interface for logging libraries",
     "keywords": ["psr", "psr-3", "log"],
+    "homepage": "https://github.com/php-fig/log",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Including the homepage link makes package mirrors and directories such as those generated by Satis nice to read and more useful (providing a direct link to the project page).