### PR TITLE
Add LoggerSpy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
I'm opening this PR to ask if a class like this one would be welcome in this package: http://pastebin.com/AniQf8dw

If the response if not a firm no, I can modify this PR to include a suitable version (no PHP-7, PSR-2 compliant, tests, ...) of that Spy.

Rationale behind the Spy: just a regular Spy. Facilitates testing of classes using a logger. (In my case I'm testing some logging decorators.) Most people would do this via the PHPUnit mock API, though this has a number of problems/downsides compared to using a simple test double like this spy:

* Breaks tools (rename refactoring, find usages, static code analysis) due to referring a method with a string
* Unless doing something complicated will bind to if the production code calls `log` to a specific level such as `error`.
* Requires a mocking framework, and developer knowledge of it