### PR TITLE
Minor syntax check and cleanup with php-cs-fixer

### DIFF
--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -103,8 +103,8 @@ abstract class LoggerInterfaceTest extends \PHPUnit_Framework_TestCase
             'string' => 'Foo',
             'int' => 0,
             'float' => 0.5,
-            'nested' => array('with object' => new DummyTest),
-            'object' => new \DateTime,
+            'nested' => array('with object' => new DummyTest()),
+            'object' => new \DateTime(),
             'resource' => fopen('php://memory', 'r'),
         );
 
@@ -122,7 +122,7 @@ abstract class LoggerInterfaceTest extends \PHPUnit_Framework_TestCase
 
         $expected = array(
             'warning Random message',
-            'critical Uncaught Exception!'
+            'critical Uncaught Exception!',
         );
         $this->assertEquals($expected, $this->getLogs());
     }


### PR DESCRIPTION
Minor syntax check and cleanup with php-cs-fixer:
```
php-cs-fixer fix . --level=symfony --fixers=\
align_equals,\
ordered_use,\
php_unit_construct,\
phpdoc_order,\
-no_empty_lines_after_phpdocs,\
-php_unit_strict,\
-phpdoc_no_empty_return,\
-psr0,\
-short_array_syntax
```