### PR TITLE
return types were incorrectly hinted as `null`, should be `void`

### DIFF
--- a/Psr/Log/AbstractLogger.php
+++ b/Psr/Log/AbstractLogger.php
@@ -17,7 +17,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function emergency($message, array $context = array())
     {
@@ -33,7 +33,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function alert($message, array $context = array())
     {
@@ -48,7 +48,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function critical($message, array $context = array())
     {
@@ -62,7 +62,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function error($message, array $context = array())
     {
@@ -78,7 +78,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function warning($message, array $context = array())
     {
@@ -91,7 +91,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function notice($message, array $context = array())
     {
@@ -106,7 +106,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function info($message, array $context = array())
     {
@@ -119,7 +119,7 @@ abstract class AbstractLogger implements LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function debug($message, array $context = array())
     {

--- a/Psr/Log/LoggerAwareInterface.php
+++ b/Psr/Log/LoggerAwareInterface.php
@@ -12,7 +12,7 @@ interface LoggerAwareInterface
      *
      * @param LoggerInterface $logger
      *
-     * @return null
+     * @return void
      */
     public function setLogger(LoggerInterface $logger);
 }

--- a/Psr/Log/LoggerInterface.php
+++ b/Psr/Log/LoggerInterface.php
@@ -25,7 +25,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function emergency($message, array $context = array());
 
@@ -38,7 +38,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function alert($message, array $context = array());
 
@@ -50,7 +50,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function critical($message, array $context = array());
 
@@ -61,7 +61,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function error($message, array $context = array());
 
@@ -74,7 +74,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function warning($message, array $context = array());
 
@@ -84,7 +84,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function notice($message, array $context = array());
 
@@ -96,7 +96,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function info($message, array $context = array());
 
@@ -106,7 +106,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function debug($message, array $context = array());
 
@@ -117,7 +117,7 @@ interface LoggerInterface
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function log($level, $message, array $context = array());
 }

--- a/Psr/Log/LoggerTrait.php
+++ b/Psr/Log/LoggerTrait.php
@@ -18,7 +18,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function emergency($message, array $context = array())
     {
@@ -34,7 +34,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function alert($message, array $context = array())
     {
@@ -49,7 +49,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function critical($message, array $context = array())
     {
@@ -63,7 +63,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function error($message, array $context = array())
     {
@@ -79,7 +79,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function warning($message, array $context = array())
     {
@@ -92,7 +92,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function notice($message, array $context = array())
     {
@@ -107,7 +107,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function info($message, array $context = array())
     {
@@ -120,7 +120,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function debug($message, array $context = array())
     {
@@ -134,7 +134,7 @@ trait LoggerTrait
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     abstract public function log($level, $message, array $context = array());
 }

--- a/Psr/Log/NullLogger.php
+++ b/Psr/Log/NullLogger.php
@@ -19,7 +19,7 @@ class NullLogger extends AbstractLogger
      * @param string $message
      * @param array  $context
      *
-     * @return null
+     * @return void
      */
     public function log($level, $message, array $context = array())
     {


### PR DESCRIPTION
Corrected all return type-hints from `null` to `void` to avoid failed inspections in e.g. Php Storm.

(strict inspection would state that a function must `return` if annotated with `return null` - as opposed to `return void`, which means the function does not use a return-statement and has no defined return-value.)