### PR TITLE
Added throws annoation to log methods

### DIFF
--- a/Psr/Log/LoggerInterface.php
+++ b/Psr/Log/LoggerInterface.php
@@ -118,6 +118,8 @@ interface LoggerInterface
      * @param array  $context
      *
      * @return void
+     *
+     * @throws \Psr\Log\InvalidArgumentException
      */
     public function log($level, $message, array $context = array());
 }

--- a/Psr/Log/LoggerTrait.php
+++ b/Psr/Log/LoggerTrait.php
@@ -135,6 +135,8 @@ trait LoggerTrait
      * @param array  $context
      *
      * @return void
+     *
+     * @throws \Psr\Log\InvalidArgumentException
      */
     abstract public function log($level, $message, array $context = array());
 }

--- a/Psr/Log/NullLogger.php
+++ b/Psr/Log/NullLogger.php
@@ -20,6 +20,8 @@ class NullLogger extends AbstractLogger
      * @param array  $context
      *
      * @return void
+     *
+     * @throws \Psr\Log\InvalidArgumentException
      */
     public function log($level, $message, array $context = array())
     {


### PR DESCRIPTION
[PSR-3 clearly states](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md) that the `log` method **MUST** throw a `Psr\Log\InvalidArgumentException` if a level is given that is not known. However, the interface and the various base implementations are missing the corresponding `@throws` annotation. Consequently IDEs do not know that such an exception could be thrown. This PR is meant to fix this circumstance.

Please note that I refrained from adding any additional documentation to the annotation, simply because everything else is completely undocumented as well.