### PR TITLE
Update LoggerInterfaceTest to be phpunit 5.7+ compatible

### DIFF
--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -11,7 +11,7 @@ use Psr\Log\LogLevel;
  * Implementors can extend the class and implement abstract methods to run this
  * as part of their test suite.
  */
-abstract class LoggerInterfaceTest extends \PHPUnit_Framework_TestCase
+abstract class LoggerInterfaceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @return LoggerInterface

--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -4,6 +4,7 @@ namespace Psr\Log\Test;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Provides a base test class for ensuring compliance with the LoggerInterface.
@@ -11,7 +12,7 @@ use Psr\Log\LogLevel;
  * Implementors can extend the class and implement abstract methods to run this
  * as part of their test suite.
  */
-abstract class LoggerInterfaceTest extends \PHPUnit\Framework\TestCase
+abstract class LoggerInterfaceTest extends TestCase
 {
     /**
      * @return LoggerInterface


### PR DESCRIPTION
\PHPUnit_Framework_TestCase does not exist in phpunit > 6

For those who want a quick fix here is how you can do it: https://github.com/vanilla/vanilla/blob/19355f36e029cd26c01dfbc5823516ee537578a4/tests/phpunit.php#L5-L13