### PR TITLE
Add a public property to LogLevel containing the levels

### DIFF
--- a/Psr/Log/LogLevel.php
+++ b/Psr/Log/LogLevel.php
@@ -15,4 +15,15 @@ class LogLevel
     const NOTICE    = 'notice';
     const INFO      = 'info';
     const DEBUG     = 'debug';
+    
+    public static $levels = [
+        self::EMERGENCY => self::EMERGENCY,
+        self::ALERT     => self::ALERT,
+        self::CRITICAL  => self::CRITICAL,
+        self::ERROR     => self::ERROR,
+        self::WARNING   => self::WARNING,
+        self::NOTICE    => self::NOTICE,
+        self::INFO      => self::INFO,
+        self::DEBUG     => self::DEBUG,
+    ];
 }


### PR DESCRIPTION
This PR introduces a new static variable to LogLevel class.

Doing this it will be easier for developers to validating/asserting the log levels.

For instance it will be easier to do this:

```
        if(!in_array($exceptionLevel, LogLevel::$levels, true)){ //or with isset()
            throw new \Exception();
        }
```
At the moment I have to maintain a class to all of my projects that extends this class and does exactly the same thing.

To tell you the truth I would prefer it if it could be a const.
