### PR TITLE
Also clear recordsByLevel in TestLogger::reset

### DIFF
--- a/Psr/Log/Test/TestLogger.php
+++ b/Psr/Log/Test/TestLogger.php
@@ -142,5 +142,6 @@ class TestLogger extends AbstractLogger
     public function reset()
     {
         $this->records = [];
+        $this->recordsByLevel = [];
     }
 }


### PR DESCRIPTION
Hi! This is the small fix for an unexpected behavior of TestLogger

```php
$logger = new TestLogger();
$logger->error('Something went wrong');
$logger->hasRecords(LogLevel::ERROR); // true
$logger->reset(); // Expect that clear all stored messages
$logger->hasRecords(LogLevel::ERROR); // true
```