### PR TITLE
Add object as typehint for message

### DIFF
--- a/Psr/Log/LoggerInterface.php
+++ b/Psr/Log/LoggerInterface.php
@@ -35,8 +35,8 @@ interface LoggerInterface
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */
@@ -47,8 +47,8 @@ interface LoggerInterface
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */
@@ -58,8 +58,8 @@ interface LoggerInterface
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */
@@ -71,8 +71,8 @@ interface LoggerInterface
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */
@@ -81,8 +81,8 @@ interface LoggerInterface
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */
@@ -93,8 +93,8 @@ interface LoggerInterface
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */
@@ -103,8 +103,8 @@ interface LoggerInterface
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */
@@ -113,9 +113,9 @@ interface LoggerInterface
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
+     * @param mixed         $level
+     * @param string|object $message
+     * @param array         $context
      *
      * @return void
      */


### PR DESCRIPTION
> Every method accepts a string as the message, or an object with a __toString() method. Implementors MAY have special handling for the passed objects. If that is not the case, implementors MUST cast it to a string.

Changes are made according to the above