### PR TITLE
Return string from DummyTest::__toString

### DIFF
--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -141,5 +141,6 @@ class DummyTest
 {
     public function __toString()
     {
+        return 'DummyTest';
     }
 }


### PR DESCRIPTION
As stated in the PHP documentation the [__toString](https://www.php.net/manual/en/language.oop5.magic.php#object.tostring) has to return a string. Currently the DummyTest::__toString method doesn't comply with this and throws errors [like this one](https://travis-ci.com/WyriHaximus/reactphp-psr-3-loggly/jobs/249440838#L550-L579) in several of my PSR-3 releated packages.

Returning a string from DummyTest::__toString as is expected by the language would solve those errors.