### PR TITLE
expectedException is deprecated in phpunit 8

### DIFF
--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -65,12 +65,10 @@ abstract class LoggerInterfaceTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Psr\Log\InvalidArgumentException
-     */
     public function testThrowsOnInvalidLevel()
     {
         $logger = $this->getLogger();
+        $this->exceptException(\Psr\Log\InvalidArgumentException::class);
         $logger->log('invalid level', 'Foo');
     }
 

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "5e1ad8887d7cf7c1facbd4ed9837904b",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
It's deprecated in PHPUnit8, and will be removed in PHPUnit9
https://github.com/sebastianbergmann/phpunit/issues/3332

@expectedException causes a warning as follows.

> The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageRegExp() instead.

