### PR TITLE
Use PSR-4 for all classes

### DIFF
--- a/Psr/Log/Test/DummyTest.php
+++ b/Psr/Log/Test/DummyTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Psr\Log\Test;
+
+/**
+ * This class is internal and does not follow the BC promise.
+ *
+ * Do NOT use this class in any way.
+ *
+ * @internal
+ */
+class DummyTest
+{
+    public function __toString()
+    {
+        return 'DummyTest';
+    }
+}

--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -136,11 +136,3 @@ abstract class LoggerInterfaceTest extends TestCase
         $this->assertEquals($expected, $this->getLogs());
     }
 }
-
-class DummyTest
-{
-    public function __toString()
-    {
-        return 'DummyTest';
-    }
-}


### PR DESCRIPTION
With great respect for PSRs and the PSR process, I dare to make this PR =). I don't think this should be an errata to the PSR since it is just a technicality. 

I want to move the DummyTest class to a separate file. This will make sure we properly use PSR4. The main reson is that static code analyser tools complain that they cannot find class `Psr\Log\Test\DummyTest`. 

The real issue is of course that we include test files in the autoload section of composer.json. They should be in autoload-dev or in a separate package. But to exclude them would mean a massive BC break. 

(I am not looking for a discussion about the best way to remove the test files or if they should be remove at all. That discussion should go in the mailing lists)

This PR is the best thing we can do to make sure we follow PSR-4 and don't break BC. 

------------

### The drawback of merging

Merging this PR will of course mean that users may instantiate the `DummyTest` class. That is the worst thing that could happen. 

`DummyTest` is marked as internal and it will not be under the BC promise. 

The "risk" of merging is none. 