### PR TITLE
Be explicit about mixed context elements

### DIFF
--- a/Psr/Log/LoggerInterface.php
+++ b/Psr/Log/LoggerInterface.php
@@ -22,8 +22,8 @@ interface LoggerInterface
     /**
      * System is unusable.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -35,8 +35,8 @@ interface LoggerInterface
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -47,8 +47,8 @@ interface LoggerInterface
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -58,8 +58,8 @@ interface LoggerInterface
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -71,8 +71,8 @@ interface LoggerInterface
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -81,8 +81,8 @@ interface LoggerInterface
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -93,8 +93,8 @@ interface LoggerInterface
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -103,8 +103,8 @@ interface LoggerInterface
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -113,9 +113,9 @@ interface LoggerInterface
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
+     * @param mixed   $level
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      *


### PR DESCRIPTION
If we do not do that, SA tools like PHPStan ask that the type be
documented more precisely in implementations.