### PR TITLE
Safe LoggerAwareTrait

### DIFF
--- a/Psr/Log/LoggerAwareTrait.php
+++ b/Psr/Log/LoggerAwareTrait.php
@@ -23,4 +23,12 @@ trait LoggerAwareTrait
     {
         $this->logger = $logger;
     }
+    
+    /**
+     * @return LoggerInterface
+     */
+    public function getLogger(): LoggerInterface
+    {
+        return $this->logger ?? new NullLogger();
+    }
 }

--- a/Psr/Log/LoggerAwareTrait.php
+++ b/Psr/Log/LoggerAwareTrait.php
@@ -23,12 +23,12 @@ trait LoggerAwareTrait
     {
         $this->logger = $logger;
     }
-    
+
     /**
      * @return LoggerInterface
      */
-    public function getLogger(): LoggerInterface
+    public function getLogger()
     {
-        return $this->logger ?? new NullLogger();
+        return !is_null($this->logger) ? $this->logger : new NullLogger();
     }
 }


### PR DESCRIPTION
Moving a logger injection form the constructor to this trait can result in run time errors as opposed to build time errors.
This change provides an error prone way to obtain the logger instance.