### PR TITLE
Fix the phpdoc of LoggerAwareTrait::$logger

### DIFF
--- a/Psr/Log/LoggerAwareTrait.php
+++ b/Psr/Log/LoggerAwareTrait.php
@@ -10,7 +10,7 @@ trait LoggerAwareTrait
     /**
      * The logger instance.
      *
-     * @var LoggerInterface
+     * @var LoggerInterface|null
      */
     protected $logger;
 


### PR DESCRIPTION
The phpdoc lies. It says that the property $logger is always LoggerInterface. This property might not be initialised, so we need to specify it in the phpdoc.