### PR TITLE
Clarify type of 2nd argument `context`

### DIFF
--- a/Psr/Log/AbstractLogger.php
+++ b/Psr/Log/AbstractLogger.php
@@ -14,8 +14,8 @@ abstract class AbstractLogger implements LoggerInterface
     /**
      * System is unusable.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -30,8 +30,8 @@ abstract class AbstractLogger implements LoggerInterface
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -45,8 +45,8 @@ abstract class AbstractLogger implements LoggerInterface
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -59,8 +59,8 @@ abstract class AbstractLogger implements LoggerInterface
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -75,8 +75,8 @@ abstract class AbstractLogger implements LoggerInterface
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -88,8 +88,8 @@ abstract class AbstractLogger implements LoggerInterface
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -103,8 +103,8 @@ abstract class AbstractLogger implements LoggerInterface
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -116,8 +116,8 @@ abstract class AbstractLogger implements LoggerInterface
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string  $message
+     * @param mixed[] $context
      *
      * @return void
      */

--- a/Psr/Log/LoggerInterface.php
+++ b/Psr/Log/LoggerInterface.php
@@ -23,7 +23,7 @@ interface LoggerInterface
      * System is unusable.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -36,7 +36,7 @@ interface LoggerInterface
      * trigger the SMS alerts and wake you up.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -48,7 +48,7 @@ interface LoggerInterface
      * Example: Application component unavailable, unexpected exception.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -59,7 +59,7 @@ interface LoggerInterface
      * be logged and monitored.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -72,7 +72,7 @@ interface LoggerInterface
      * that are not necessarily wrong.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -82,7 +82,7 @@ interface LoggerInterface
      * Normal but significant events.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -94,7 +94,7 @@ interface LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -104,7 +104,7 @@ interface LoggerInterface
      * Detailed debug information.
      *
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      */
@@ -115,7 +115,7 @@ interface LoggerInterface
      *
      * @param mixed   $level
      * @param string  $message
-     * @param array $context
+     * @param mixed[] $context
      *
      * @return void
      *

--- a/Psr/Log/LoggerInterface.php
+++ b/Psr/Log/LoggerInterface.php
@@ -23,7 +23,7 @@ interface LoggerInterface
      * System is unusable.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -36,7 +36,7 @@ interface LoggerInterface
      * trigger the SMS alerts and wake you up.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -48,7 +48,7 @@ interface LoggerInterface
      * Example: Application component unavailable, unexpected exception.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -59,7 +59,7 @@ interface LoggerInterface
      * be logged and monitored.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -72,7 +72,7 @@ interface LoggerInterface
      * that are not necessarily wrong.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -82,7 +82,7 @@ interface LoggerInterface
      * Normal but significant events.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -94,7 +94,7 @@ interface LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -104,7 +104,7 @@ interface LoggerInterface
      * Detailed debug information.
      *
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      */
@@ -115,7 +115,7 @@ interface LoggerInterface
      *
      * @param mixed   $level
      * @param string  $message
-     * @param mixed[] $context
+     * @param array $context
      *
      * @return void
      *


### PR DESCRIPTION
According to psalm, there is an error:

> ERROR: MethodSignatureMismatch - ide/5.0.0-alpha.1/Phalcon/DataMapper/Pdo/Profiler/MemoryLogger.zep.php:21:7 - Argument 2 of Psr\Log\AbstractLogger::alert has wrong type 'mixed', expecting 'array<array-key, mixed>' as defined by Psr\Log\LoggerInterface::alert (see https://psalm.dev/042)

This blocks https://github.com/phalcon/cphalcon/pull/15362