### PR TITLE
Remove illegal annotation

### DIFF
--- a/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/Psr/Log/Test/LoggerInterfaceTest.php
@@ -65,12 +65,11 @@ abstract class LoggerInterfaceTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Psr\Log\InvalidArgumentException
-     */
     public function testThrowsOnInvalidLevel()
     {
         $logger = $this->getLogger();
+
+        $this->expectException(InvalidArgumentException::class);
         $logger->log('invalid level', 'Foo');
     }
 


### PR DESCRIPTION
The `@expectedException` annotation is deprecated, and [removed][migrating] in PHPUnit 9. When testing with PHPUnit 8, the following warning appears for every time a logger test is run:

> The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.

With PHPUnit 9.5.4, the tests fail with the following error:

> Inpsyde\WooCommerceLogging\Tests\Functional\AbstractLoggerTest::testThrowsOnInvalidLevel
> Psr\Log\InvalidArgumentException: Unknown log level "invalid level"
>
> /home/runner/work/product-woocommerce-logging/product-woocommerce-logging/src/AbstractLogger.php:42
> /home/runner/work/product-woocommerce-logging/product-woocommerce-logging/vendor/psr/log/Psr/Log/Test/LoggerInterfaceTest.php:74

[migrating]: https://thephp.cc/articles/migrating-to-phpunit-9