### PR TITLE
Add return types for v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }

--- a/src/LoggerAwareInterface.php
+++ b/src/LoggerAwareInterface.php
@@ -14,5 +14,5 @@ interface LoggerAwareInterface
      *
      * @return void
      */
-    public function setLogger(LoggerInterface $logger);
+    public function setLogger(LoggerInterface $logger): void;
 }

--- a/src/LoggerAwareTrait.php
+++ b/src/LoggerAwareTrait.php
@@ -19,7 +19,7 @@ trait LoggerAwareTrait
      *
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -27,7 +27,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function emergency(string|\Stringable $message, array $context = []);
+    public function emergency(string|\Stringable $message, array $context = []): void;
 
     /**
      * Action must be taken immediately.
@@ -40,7 +40,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function alert(string|\Stringable $message, array $context = []);
+    public function alert(string|\Stringable $message, array $context = []): void;
 
     /**
      * Critical conditions.
@@ -52,7 +52,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function critical(string|\Stringable $message, array $context = []);
+    public function critical(string|\Stringable $message, array $context = []): void;
 
     /**
      * Runtime errors that do not require immediate action but should typically
@@ -63,7 +63,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function error(string|\Stringable $message, array $context = []);
+    public function error(string|\Stringable $message, array $context = []): void;
 
     /**
      * Exceptional occurrences that are not errors.
@@ -76,7 +76,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function warning(string|\Stringable $message, array $context = []);
+    public function warning(string|\Stringable $message, array $context = []): void;
 
     /**
      * Normal but significant events.
@@ -86,7 +86,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function notice(string|\Stringable $message, array $context = []);
+    public function notice(string|\Stringable $message, array $context = []): void;
 
     /**
      * Interesting events.
@@ -98,7 +98,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function info(string|\Stringable $message, array $context = []);
+    public function info(string|\Stringable $message, array $context = []): void;
 
     /**
      * Detailed debug information.
@@ -108,7 +108,7 @@ interface LoggerInterface
      *
      * @return void
      */
-    public function debug(string|\Stringable $message, array $context = []);
+    public function debug(string|\Stringable $message, array $context = []): void;
 
     /**
      * Logs with an arbitrary level.
@@ -121,5 +121,5 @@ interface LoggerInterface
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, string|\Stringable $message, array $context = []);
+    public function log($level, string|\Stringable $message, array $context = []): void;
 }

--- a/src/LoggerTrait.php
+++ b/src/LoggerTrait.php
@@ -20,7 +20,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function emergency(string|\Stringable $message, array $context = [])
+    public function emergency(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::EMERGENCY, $message, $context);
     }
@@ -36,7 +36,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function alert(string|\Stringable $message, array $context = [])
+    public function alert(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::ALERT, $message, $context);
     }
@@ -51,7 +51,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function critical(string|\Stringable $message, array $context = [])
+    public function critical(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::CRITICAL, $message, $context);
     }
@@ -65,7 +65,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function error(string|\Stringable $message, array $context = [])
+    public function error(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::ERROR, $message, $context);
     }
@@ -81,7 +81,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function warning(string|\Stringable $message, array $context = [])
+    public function warning(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::WARNING, $message, $context);
     }
@@ -94,7 +94,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function notice(string|\Stringable $message, array $context = [])
+    public function notice(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::NOTICE, $message, $context);
     }
@@ -109,7 +109,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function info(string|\Stringable $message, array $context = [])
+    public function info(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::INFO, $message, $context);
     }
@@ -122,7 +122,7 @@ trait LoggerTrait
      *
      * @return void
      */
-    public function debug(string|\Stringable $message, array $context = [])
+    public function debug(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::DEBUG, $message, $context);
     }
@@ -138,5 +138,5 @@ trait LoggerTrait
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    abstract public function log($level, string|\Stringable $message, array $context = []);
+    abstract public function log($level, string|\Stringable $message, array $context = []): void;
 }

--- a/src/NullLogger.php
+++ b/src/NullLogger.php
@@ -23,7 +23,7 @@ class NullLogger extends AbstractLogger
      *
      * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, string|\Stringable $message, array $context = [])
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
         // noop
     }


### PR DESCRIPTION
The return types are all void, so this is a pretty boring addition.  This necessarily includes the v2 branch, which should be reviewed in its own PR #76.

See the [one extra commit](https://github.com/php-fig/log/commit/30da42a08607f9d3017db365ff03dbdcc39670ac) for the specific changes in this PR.