### PR TITLE
Narrow supported log level phpdoc

### DIFF
--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -113,7 +113,7 @@ interface LoggerInterface
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed   $level
+     * @param LogLevel::*   $level
      * @param string|\Stringable $message
      * @param mixed[] $context
      *

--- a/src/LoggerTrait.php
+++ b/src/LoggerTrait.php
@@ -130,7 +130,7 @@ trait LoggerTrait
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
+     * @param LogLevel::*  $level
      * @param string|\Stringable $message
      * @param array  $context
      *

--- a/src/NullLogger.php
+++ b/src/NullLogger.php
@@ -15,7 +15,7 @@ class NullLogger extends AbstractLogger
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
+     * @param LogLevel::*  $level
      * @param string|\Stringable $message
      * @param array $context
      *


### PR DESCRIPTION
Only the `LogLevel::*` log levels need to be supported per https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#11-basics

User can still widen the accepted type like `LogLevel::*|'xxx'` thanks to LSP.