### PR TITLE
Fix $context type-hint

### DIFF
--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -23,7 +23,7 @@ interface LoggerInterface
      * System is unusable.
      *
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      */
@@ -36,7 +36,7 @@ interface LoggerInterface
      * trigger the SMS alerts and wake you up.
      *
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      */
@@ -48,7 +48,7 @@ interface LoggerInterface
      * Example: Application component unavailable, unexpected exception.
      *
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      */
@@ -72,7 +72,7 @@ interface LoggerInterface
      * that are not necessarily wrong.
      *
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      */
@@ -82,7 +82,7 @@ interface LoggerInterface
      * Normal but significant events.
      *
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      */
@@ -94,7 +94,7 @@ interface LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      */
@@ -104,7 +104,7 @@ interface LoggerInterface
      * Detailed debug information.
      *
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      */
@@ -115,7 +115,7 @@ interface LoggerInterface
      *
      * @param mixed   $level
      * @param string|\Stringable $message
-     * @param mixed[] $context
+     * @param array<string,mixed> $context
      *
      * @return void
      *


### PR DESCRIPTION
PR #70 was unfortunately wrong: `mixed[]` means a *list* (in PHP, array with `int` keys) of `mixed` values.

This is by no means correct, since the key is typically a string, as seen in [examples](https://www.php-fig.org/psr/psr-3/#13-context:~:text=function%20interpolate(%24message%2C%20array%20%24context%20%3D%20array())) and inferred from [§ 1.3 Context](https://www.php-fig.org/psr/psr-3/#13-context), and given that [placeholders must correspond to context keys](https://www.php-fig.org/psr/psr-3/#13-context:~:text=Placeholder%20names%20MUST%20correspond%20to%20keys%20in%20the%20context%20array.) and that [placeholder names should follow a specific format](https://www.php-fig.org/psr/psr-3/#13-context:~:text=Placeholder%20names%20SHOULD%20be%20composed%20only%20of%20the%20characters%20A%2DZ%2C%20a%2Dz%2C%200%2D9%2C%20underscore%20_%2C%20and%20period%20..%20The%20use%20of%20other%20characters%20is%20reserved%20for%20future%20modifications%20of%20the%20placeholders%20specification.).

Although to be fair, it's not entirely clear in the specification which types are allowed for keys.

I _think_, it should be `array<string, mixed>`, but it could also be `array<mixed, mixed>` to be fully backward compatible.