### PR TITLE
Restore a phpdoc

### DIFF
--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -89,6 +89,7 @@ interface LoggerInterface
     /**
      * Logs with an arbitrary level.
      *
+     * @param mixed $level
      * @param mixed[] $context
      *
      * @throws \Psr\Log\InvalidArgumentException


### PR DESCRIPTION
v3.0.1 removed this line at https://github.com/php-fig/log/commit/79dff0b268932c640297f5208d6298f71855c03e#diff-ece1cc9e2cbefb0d1c511f88ab22703e9a402b9ca071df66704f1106c1433ad4L116 (in PR https://github.com/php-fig/log/pull/80), however it isn't covered by a typehint so broke static analysis checks in consuming applications/packages which implement this interface